### PR TITLE
Update localhost troubleshooting documentation

### DIFF
--- a/docs/localhost.md
+++ b/docs/localhost.md
@@ -17,4 +17,3 @@ We apologize for the inconvenience, and we appreciate your understanding as we w
 Description | Link
 --- | ---
 Official Microsoft docs explaining that UWP apps installed from the store aren't allowed to make network calls to the device they're installed on. | https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/deploying-and-debugging-uwp-apps#debugging-options
-Windows Platform UserVoice requesting for network loopback support. | https://wpdev.uservoice.com/forums/110705-universal-windows-platform/suggestions/36604855-allow-localhost-loopback-capability-in-uwp-apps-de


### PR DESCRIPTION
Removes a dead link to the old Windows Platform Development UserVoice.

If desired for future reference, another alternative would be to link the [archived version of the page](https://web.archive.org/web/20190323151500/https://wpdev.uservoice.com/forums/110705-universal-windows-platform/suggestions/36604855-allow-localhost-loopback-capability-in-uwp-apps-de).